### PR TITLE
Adds support for route-level redirects

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -5,7 +5,13 @@ require 'yaml'
 
 def get_url(domain_object, rel_route)
   if domain_object.is_a? Hash
-    return domain_object['root'] + "/" + rel_route
+    if domain_object.key? 'root'
+      domain_object['root'] + '/' + rel_route
+    elsif domain_object.key? rel_route
+      domain_object[rel_route]
+    else
+      domain_object.values.first
+    end
   elsif domain_object.is_a? String
     return domain_object
   end


### PR DESCRIPTION
Let's you do [this](https://github.com/harman28/lightsaber/blob/master/redirects.yml#L17):

```sh
# where.rzp.io/delhi -> https://goo.gl/maps/1A9nhMPzehS2
# where.rzp.io/gurgaon -> https://goo.gl/maps/PX2apgMYQ6L2
where.rzp.io:
  delhi: https://goo.gl/maps/1A9nhMPzehS2
  gurgaon: https://goo.gl/maps/PX2apgMYQ6L2
```

Defaults to first option if no route is given.